### PR TITLE
DSU: Only try to install on sdcard if the filesystem in use is vfat

### DIFF
--- a/services/core/java/com/android/server/DynamicSystemService.java
+++ b/services/core/java/com/android/server/DynamicSystemService.java
@@ -91,6 +91,10 @@ public class DynamicSystemService extends IDynamicSystemService.Stub {
                 if (!volume.isMountedWritable()) {
                     continue;
                 }
+                // gsid only supports vfat external storage.
+                if (!"vfat".equalsIgnoreCase(volume.fsType)) {
+                    continue;
+                }
                 DiskInfo disk = volume.getDisk();
                 long mega = disk.size >> 20;
                 Slog.i(TAG, volume.getPath() + ": " + mega + " MB");


### PR DESCRIPTION
IsExternalStoragePath() in gsid only allows vfat

Test: m; Install DSU on a device using exFAT for external sdcard

Change-Id: I6073b268ead79d684422e4ef1fa3873713dd602e