### PR TITLE
fw/b: Introduce dynamically themed bootanimation

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/theme/ThemeOverlayController.java
+++ b/packages/SystemUI/src/com/android/systemui/theme/ThemeOverlayController.java
@@ -42,6 +42,7 @@ import android.content.res.Resources;
 import android.database.ContentObserver;
 import android.graphics.Color;
 import android.net.Uri;
+import android.os.SystemProperties;
 import android.os.Handler;
 import android.os.UserHandle;
 import android.os.UserManager;
@@ -122,7 +123,7 @@ public class ThemeOverlayController extends CoreStartable implements Dumpable {
     private final Handler mBgHandler;
     private final boolean mIsMonetEnabled;
     private final UserTracker mUserTracker;
-    private final ConfigurationController mConfigurationController;
+    private ConfigurationController mConfigurationController;
     private final DeviceProvisionedController mDeviceProvisionedController;
     private final Resources mResources;
     // Current wallpaper colors associated to a user.
@@ -160,6 +161,11 @@ public class ThemeOverlayController extends CoreStartable implements Dumpable {
                     Log.i(TAG, "Re-applying theme on UI change");
                     reevaluateSystemTheme(true /* forceReload */);
                 }
+
+		@Override
+		public void onThemeChanged() {
+		    setBootColorProps();
+		}
             };
 
     private final DeviceProvisionedListener mDeviceProvisionedListener =
@@ -378,6 +384,7 @@ public class ThemeOverlayController extends CoreStartable implements Dumpable {
         mIsMonetEnabled = featureFlags.isEnabled(Flags.MONET);
         mConfigurationController = configurationController;
         mDeviceProvisionedController = deviceProvisionedController;
+        mConfigurationController.addCallback(mConfigurationListener);
         mBroadcastDispatcher = broadcastDispatcher;
         mUserManager = userManager;
         mBgExecutor = bgExecutor;
@@ -481,7 +488,6 @@ public class ThemeOverlayController extends CoreStartable implements Dumpable {
 
         mUserTracker.addCallback(mUserTrackerCallback, mMainExecutor);
 
-        mConfigurationController.addCallback(mConfigurationListener);
         mDeviceProvisionedController.addCallback(mDeviceProvisionedListener);
 
         // All wallpaper color and keyguard logic only applies when Monet is enabled.
@@ -529,6 +535,25 @@ public class ThemeOverlayController extends CoreStartable implements Dumpable {
                 }
             }
         });
+
+        // To set props without needing an overlay change, Usually the props are only set when you first change wallpaper i.e after overlay change.
+        // we wish to avoid this, call setBootColorProps at the start of service, this will set props on boot so by the time you first reboot,
+        // boot colors would already be there and bootanim would be colored.
+        setBootColorProps();
+    }
+
+    private void setBootColorProps() {
+        // persist.bootanim.color1, persist.bootanim.color2, persist.bootanim.color3, persist.bootanim.color4
+        int[] bootColors = {android.R.color.system_accent3_100, android.R.color.system_accent1_300, android.R.color.system_accent2_500, android.R.color.system_accent1_100};
+        try {
+            for (int i = 0; i < bootColors.length; i++) {
+                String color = String.valueOf(mResources.getColor(bootColors[i]));
+                SystemProperties.set(String.format("persist.bootanim.color%d", i + 1), color);
+                Log.d("ThemeOverlayController", String.format("Writing boot color boot animation colors: %d %s", i, color));
+            }
+        } catch (RuntimeException e) {
+            Log.w("ThemeOverlayController", "Cannot set sysprop. Look for 'init' and 'dmesg' logs for more info.");
+        }
     }
 
     private void reevaluateSystemTheme(boolean forceReload) {


### PR DESCRIPTION
[Waxaranai]: Adapt code to A13

A majority of the code was already merged into AOSP during the R16/QPR1 merge, what was missing was interaction with ThemeOverlayController to actually set these props for them to be utilised.

Here's a brief explaination of how it works:
Monet theme is generated. and mConfigurationListener in ThemeOverlayController detects the overlay change, this leads to it calling setBootColorProps which sets 4 props (persist.bootanim.color{1, 2, 3, 4)} These props are what store the colors, they get colors from all 3 accent categories (Primary, Secondary and Tertiary). setBootColorProps is also called at the end of start (void start()) to avoid actually needing to regenerate overlays for people that like the default wallpaper.

Note: Making a bootanimation which works with this IS NOT easy. You'd need to mess with opacity and colors of all sorts to get these colored and then also take care of the aliasing and sharp edges with extra pixels, not for the faint hearted.

Change-Id: Ic095ec6a55b97ac2943e5eb079068b271633547a
Signed-off-by: Maitreya29 <maitreyapatni30@gmail.com>
Signed-off-by: Waxaranai <waxaranai@gmail.com>