### PR TITLE
SystemUI: allow set combined QS with config

### DIFF
--- a/packages/SystemUI/res/values/flags.xml
+++ b/packages/SystemUI/res/values/flags.xml
@@ -45,4 +45,7 @@
 
     <bool name="flag_combined_status_bar_signal_icons">true</bool>
 
+    <!-- Whether the combined qs shows in status bar when true, the combined qs will not be available
+         if set it to false  -->
+    <bool name="flag_combined_qs_headers">true</bool>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/flags/Flags.kt
+++ b/packages/SystemUI/src/com/android/systemui/flags/Flags.kt
@@ -220,7 +220,7 @@ object Flags {
     // 500 - quick settings
 
     // TODO(b/254512321): Tracking Bug
-    @JvmField val COMBINED_QS_HEADERS = releasedFlag(501, "combined_qs_headers")
+    @JvmField val COMBINED_QS_HEADERS = resourceBooleanFlag(501, R.bool.flag_combined_qs_headers, "combined_qs_headers")
     val PEOPLE_TILE = resourceBooleanFlag(502, R.bool.flag_conversations, "people_tile")
 
     @JvmField


### PR DESCRIPTION
- legacy devices have some issue with it. instead of removing it let make it config. so that people who want can use it and other's can be happy without lag
- inspired from https://gerrit.aospa.co/c/AOSPA/android_frameworks_base/+/24531