### PR TITLE
Workaround Status bar lyric for some Chinese apps

### DIFF
--- a/core/java/android/app/Instrumentation.java
+++ b/core/java/android/app/Instrumentation.java
@@ -41,6 +41,7 @@ import android.os.Process;
 import android.os.RemoteException;
 import android.os.ServiceManager;
 import android.os.SystemClock;
+import android.os.SystemProperties;
 import android.os.TestLooperManager;
 import android.os.UserHandle;
 import android.util.AndroidRuntimeException;
@@ -65,6 +66,7 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 import com.android.internal.util.derp.PixelPropsUtils;
+import com.android.internal.util.derp.MeizuPropsUtils;
 
 /**
  * Base class for implementing application instrumentation code.  When running
@@ -94,6 +96,8 @@ public class Instrumentation {
     private static final String TAG = "Instrumentation";
 
     private static final long CONNECT_TIMEOUT_MILLIS = 5000;
+
+    private static final String DISGUISE_PROPS_FOR_MUSIC_APP = "persist.sys.disguise_props_for_music_app";
 
     /**
      * @hide
@@ -1246,6 +1250,9 @@ public class Instrumentation {
         app.attach(context);
         String packageName = context.getPackageName();
         PixelPropsUtils.setProps(packageName);
+        if (SystemProperties.getBoolean(DISGUISE_PROPS_FOR_MUSIC_APP, false)) {
+            MeizuPropsUtils.setProps(packageName);
+        }
         return app;
     }
     
@@ -1265,6 +1272,9 @@ public class Instrumentation {
         app.attach(context);
         String packageName = context.getPackageName();
         PixelPropsUtils.setProps(packageName);
+        if (SystemProperties.getBoolean(DISGUISE_PROPS_FOR_MUSIC_APP, false)) {
+            MeizuPropsUtils.setProps(packageName);
+        }
         return app;
     }
 

--- a/core/java/com/android/internal/util/derp/MeizuPropsUtils.java
+++ b/core/java/com/android/internal/util/derp/MeizuPropsUtils.java
@@ -1,0 +1,85 @@
+
+/*
+ * Copyright (C) 2020 The Pixel Experience Project
+ *               2020 The exTHmUI Open Source Project
+ *               2022 Project Kaleidoscope
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.internal.util.derp;
+
+import android.os.Build;
+import android.util.Log;
+
+import java.util.Arrays;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MeizuPropsUtils {
+
+    private static final String TAG = MeizuPropsUtils.class.getSimpleName();
+    private static final boolean DEBUG = false;
+
+    private static final Map<String, Object> propsToChange;
+
+    private static final String[] packagesToChange = {
+        "com.netease.cloudmusic",
+        "com.tencent.qqmusic",
+        "com.kugou.android",
+        "com.kugou.android.lite",
+        "cmccwm.mobilemusic",
+        "cn.kuwo.player",
+        "com.meizu.media.music"
+    };
+
+    static {
+        propsToChange = new HashMap<>();
+        propsToChange.put("BRAND", "meizu");
+        propsToChange.put("MANUFACTURER", "Meizu");
+        propsToChange.put("DEVICE", "m1892");
+        propsToChange.put("DISPLAY","Flyme");
+        propsToChange.put("PRODUCT","meizu_16thPlus_CN");
+        propsToChange.put("MODEL", "meizu 16th Plus");
+    }
+
+    public static void setProps(String packageName) {
+        if (packageName == null){
+            return;
+        }
+        if (Arrays.asList(packagesToChange).contains(packageName)){
+            if (DEBUG){
+                Log.d(TAG, "Defining props for: " + packageName);
+            }
+            for (Map.Entry<String, Object> prop : propsToChange.entrySet()) {
+                String key = prop.getKey();
+                Object value = prop.getValue();
+                setPropValue(key, value);
+            }
+        }
+    }
+
+    private static void setPropValue(String key, Object value){
+        try {
+            if (DEBUG){
+                Log.d(TAG, "Defining prop " + key + " to " + value.toString());
+            }
+            Field field = Build.class.getDeclaredField(key);
+            field.setAccessible(true);
+            field.set(null, value);
+            field.setAccessible(false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            Log.e(TAG, "Failed to set prop " + key, e);
+        }
+    }
+}


### PR DESCRIPTION
- Reset props to Meizu in some apps to use status bar lyric

Some Chinese music apps (such as NetEase Cloud Music) require a specific phone to enable status bar lyrics correctly. We need to spoof device props to them. Pick this workaround from Project Kaleidoscope ( sadly discontinued ) to make it work.

Tests: Open Netease Cloud Music and enable status bar lyric, it works fine.