### PR TITLE
base: Do not reset keyguard going away state

### DIFF
--- a/core/java/com/android/internal/util/derp/udfps/UdfpsUtils.java
+++ b/core/java/com/android/internal/util/derp/udfps/UdfpsUtils.java
@@ -1,0 +1,29 @@
+/*
+* Copyright (C) 2022-23 Project Blaze
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package com.android.internal.util.derp.udfps;
+
+import android.content.Context;
+
+import com.android.internal.util.ArrayUtils;
+
+public class UdfpsUtils {
+    public static boolean hasUdfpsSupport(Context context) {
+        int[] udfpsProps = context.getResources().getIntArray(
+                com.android.internal.R.array.config_udfps_sensor_props);
+
+        return !ArrayUtils.isEmpty(udfpsProps);
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
@@ -105,6 +105,7 @@ import com.android.internal.policy.IKeyguardStateCallback;
 import com.android.internal.policy.ScreenDecorationsUtils;
 import com.android.internal.statusbar.IStatusBarService;
 import com.android.internal.util.LatencyTracker;
+import com.android.internal.util.derp.udfps.UdfpsUtils;
 import com.android.internal.widget.LockPatternUtils;
 import com.android.keyguard.KeyguardConstants;
 import com.android.keyguard.KeyguardDisplayManager;
@@ -1439,7 +1440,10 @@ public class KeyguardViewMediator implements CoreStartable, Dumpable,
         // explicitly DO NOT want to call
         // mKeyguardViewControllerLazy.get().setKeyguardGoingAwayState(false)
         // here, since that will mess with the device lock state.
-        mUpdateMonitor.dispatchKeyguardGoingAway(false);
+        boolean isUdfps = deviceHasUdfps();
+        if (!isUdfps) {
+            mUpdateMonitor.dispatchKeyguardGoingAway(false);
+        }
 
         notifyStartedGoingToSleep();
     }
@@ -3520,5 +3524,9 @@ public class KeyguardViewMediator implements CoreStartable, Dumpable,
 
             mInteractionJankMonitor.cancel(CUJ_LOCKSCREEN_OCCLUSION);
         }
+    }
+
+    private boolean deviceHasUdfps() {
+        return UdfpsUtils.hasUdfpsSupport(mContext);
     }
 }


### PR DESCRIPTION
Fixes the flicker on turning off the screen when udfps is enabled
It will completely fix the issue When the screen automatically stops after timeout, the screen will flash with the highest brightness(for UDFPS)