### PR TITLE
base: PreferredNetworkTile: Disable tile on Wi-Fi tablets

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/PreferredNetworkTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/PreferredNetworkTile.java
@@ -80,7 +80,7 @@ public class PreferredNetworkTile extends SecureQSTile<State> {
 
     @Override
     public boolean isAvailable() {
-        return true;
+        return mTelephonyManager.getPhoneType() != TelephonyManager.PHONE_TYPE_NONE;
     }
 
     @Override


### PR DESCRIPTION
- Requires config_voiceCapable to be false for this check to validate
- Fixes QS tiles editing:
Error in handleRefreshState
java.lang.IllegalStateException: telephony service is null.
	at android.telephony.TelephonyManager.getAllowedNetworkTypesForReason(TelephonyManager.java:9470)
	at com.android.systemui.qs.tiles.PreferredNetworkTile.getPreferredNetworkMode(PreferredNetworkTile.java:147)
	at com.android.systemui.qs.tiles.PreferredNetworkTile.handleUpdateState(PreferredNetworkTile.java:121)
	at com.android.systemui.qs.tileimpl.QSTileImpl.handleRefreshState(QSTileImpl.java:461)
	at com.android.systemui.qs.tileimpl.QSTileImpl$H.handleMessage(QSTileImpl.java:637)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loopOnce(Looper.java:201)
	at android.os.Looper.loop(Looper.java:288)
	at android.os.HandlerThread.run(HandlerThread.java:67)