### PR TITLE
BatteryService: Switch Vooc charging status path to an overlay

### DIFF
--- a/core/res/res/values/derp_config.xml
+++ b/core/res/res/values/derp_config.xml
@@ -298,6 +298,9 @@
   <!-- Paths to OP warp charging status file -->
   <string name="config_opWarpChargerStatusPaths" translatable="false">/sys/class/power_supply/battery/fastchg_status</string>
 
+  <!-- Paths to realme's vooc charging status file -->
+  <string name="config_VoocChargerStatusPaths" translatable="false">/sys/class/power_supply/battery/voocchg_ing</string>
+
     <!-- Whether device has dash charging support -->
     <bool name="config_hasDashCharger">false</bool>
 

--- a/core/res/res/values/derp_symbols.xml
+++ b/core/res/res/values/derp_symbols.xml
@@ -187,6 +187,9 @@
   <!-- Paths to OP warp charging status file -->
   <java-symbol type="string" name="config_opWarpChargerStatusPaths" />
 
+  <!-- Paths to realme's vooc charging status file -->
+  <java-symbol type="string" name="config_VoocChargerStatusPaths" />
+
   <!-- Whether device has dash charging support -->
   <java-symbol type="bool" name="config_hasDashCharger" />
 

--- a/services/core/java/com/android/server/BatteryService.java
+++ b/services/core/java/com/android/server/BatteryService.java
@@ -183,6 +183,7 @@ public final class BatteryService extends SystemService {
     private boolean mVoocCharger;
     private boolean mHasVoocCharger;
     private boolean mLastVoocCharger;
+    private String mVoocChargerPath;
 
     private boolean mTurboPower;
     private boolean mHasTurboPower;
@@ -861,8 +862,9 @@ public final class BatteryService extends SystemService {
     }
 
     private boolean isVoocCharger() {
+        mVoocChargerPath = mContext.getResources().getString(com.android.internal.R.string.config_VoocChargerStatusPaths);
         try {
-            FileReader file = new FileReader("/sys/class/power_supply/battery/voocchg_ing");
+            FileReader file = new FileReader(mVoocChargerPath);
             BufferedReader br = new BufferedReader(file);
             String state = br.readLine();
             br.close();


### PR DESCRIPTION
* Based on 6a1fd33
* set default '/sys/class/power_supply/battery/voocchg_ing' to keep existing devices safe