### PR TITLE
DozeSensors: only use proximity sensor if supported

### DIFF
--- a/packages/SystemUI/res/values/derp_config.xml
+++ b/packages/SystemUI/res/values/derp_config.xml
@@ -7,4 +7,7 @@
 
     <!-- Color of the UDFPS pressed view -->
     <color name="config_udfpsColor">#ffffffff</color>
+
+    <!-- Whether usage of the proximity sensor during doze is supported -->
+    <bool name="doze_proximity_sensor_supported">true</bool>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/doze/DozeSensors.java
+++ b/packages/SystemUI/src/com/android/systemui/doze/DozeSensors.java
@@ -283,13 +283,15 @@ public class DozeSensors {
                         false /* requiresAod */
                 ),
         };
-        setProxListening(false);  // Don't immediately start listening when we register.
-        mProximitySensor.register(
-                proximityEvent -> {
-                    if (proximityEvent != null) {
-                        mProxCallback.accept(!proximityEvent.getBelow());
-                    }
-                });
+        if (resources.getBoolean(com.android.systemui.R.bool.doze_proximity_sensor_supported)) {
+            setProxListening(false);  // Don't immediately start listening when we register.
+            mProximitySensor.register(
+                    proximityEvent -> {
+                        if (proximityEvent != null) {
+                            mProxCallback.accept(!proximityEvent.getBelow());
+                        }
+                    });
+        }
 
         mDevicePostureController.addCallback(mDevicePostureCallback);
     }


### PR DESCRIPTION
On msm-4.14 devices, when the proximity sensor is in use, the smp2p-sleepstate IRQ is fired multiple times a second, with each one holding a 200ms wakelock.
This is probably a bug in the DSP firmware.
To fix this, avoid using the proximity sensor in doze mode, because sleep is preferred to turning off the screen.

Change-Id: I57750afd77267abdc49780f70636626d20e666ad