### PR TITLE
Prevent a series of null pointer dereference

### DIFF
--- a/cmds/incidentd/src/IncidentService.cpp
+++ b/cmds/incidentd/src/IncidentService.cpp
@@ -533,7 +533,7 @@ status_t IncidentService::onTransact(uint32_t code, const Parcel& data, Parcel* 
                 fflush(fout);
                 fclose(fout);
             }
-            if (fout != NULL) {
+            if (ferr != NULL) {
                 fflush(ferr);
                 fclose(ferr);
             }

--- a/core/java/android/view/GestureDetector.java
+++ b/core/java/android/view/GestureDetector.java
@@ -841,8 +841,10 @@ public class GestureDetector {
         mHandler.removeMessages(SHOW_PRESS);
         mHandler.removeMessages(LONG_PRESS);
         mHandler.removeMessages(TAP);
-        mVelocityTracker.recycle();
-        mVelocityTracker = null;
+        if (mVelocityTracker != null) {
+            mVelocityTracker.recycle();
+            mVelocityTracker = null;
+        }
         mIsDoubleTapping = false;
         mStillDown = false;
         mAlwaysInTapRegion = false;

--- a/core/java/android/view/View.java
+++ b/core/java/android/view/View.java
@@ -28120,10 +28120,12 @@ public class View implements Drawable.Callback, KeyEvent.Callback,
             Log.e(VIEW_LOG_TAG, "Unable to initiate drag", e);
             return false;
         } finally {
-            if (token == null) {
+            if (session != null) {
+                session.kill();
+            }
+            if (token == null && surface != null) {
                 surface.destroy();
             }
-            session.kill();
         }
     }
 

--- a/libs/WindowManager/Shell/src/com/android/wm/shell/splitscreen/StageCoordinator.java
+++ b/libs/WindowManager/Shell/src/com/android/wm/shell/splitscreen/StageCoordinator.java
@@ -1578,6 +1578,7 @@ public class StageCoordinator implements SplitLayout.SplitLayoutHandler,
     }
 
     void getStageBounds(Rect outTopOrLeftBounds, Rect outBottomOrRightBounds) {
+        if (mSplitLayout == null) return;
         outTopOrLeftBounds.set(mSplitLayout.getBounds1());
         outBottomOrRightBounds.set(mSplitLayout.getBounds2());
     }

--- a/libs/hwui/AnimatorManager.cpp
+++ b/libs/hwui/AnimatorManager.cpp
@@ -112,7 +112,9 @@ public:
         *mDirtyMask |= animator->dirtyMask();
         bool remove = animator->animate(mContext);
         if (remove) {
-            animator->detach();
+            if (animator) {
+                animator->detach();
+            }
         } else {
             if (animator->isRunning()) {
                 mInfo.out.hasAnimations = true;

--- a/libs/hwui/AnimatorManager.cpp
+++ b/libs/hwui/AnimatorManager.cpp
@@ -77,7 +77,7 @@ void AnimatorManager::pushStaging() {
 
         // Only add new animators that are not already in the mAnimators list
         for (auto& anim : mNewAnimators) {
-            if (anim->target() != &mParent) {
+            if (anim && anim->target() != &mParent) {
                 mAnimators.push_back(std::move(anim));
             }
         }
@@ -86,12 +86,14 @@ void AnimatorManager::pushStaging() {
 
     if (mCancelAllAnimators) {
         for (auto& animator : mAnimators) {
-            animator->forceEndNow(mAnimationHandle->context());
+            if (animator)
+                animator->forceEndNow(mAnimationHandle->context());
         }
         mCancelAllAnimators = false;
     } else {
         for (auto& animator : mAnimators) {
-            animator->pushStaging(mAnimationHandle->context());
+            if (animator)
+                animator->pushStaging(mAnimationHandle->context());
         }
     }
 }

--- a/libs/hwui/renderthread/DrawFrameTask.cpp
+++ b/libs/hwui/renderthread/DrawFrameTask.cpp
@@ -82,7 +82,9 @@ int DrawFrameTask::drawFrame() {
 void DrawFrameTask::postAndWait() {
     ATRACE_CALL();
     AutoMutex _lock(mLock);
-    mRenderThread->queue().post([this]() { run(); });
+    if (mRenderThread) {
+      mRenderThread->queue().post([this]() { run(); });
+    }
     mSignal.wait(mLock);
 }
 

--- a/packages/SystemUI/src/com/android/systemui/ScreenDecorations.java
+++ b/packages/SystemUI/src/com/android/systemui/ScreenDecorations.java
@@ -1076,7 +1076,12 @@ public class ScreenDecorations implements CoreStartable, Tunable , Dumpable {
                 }
             }
         }
-        mRoundedCornerResDelegate.dump(pw, args);
+        if (!DEBUG_DISABLE_SCREEN_DECORATIONS) {
+            mRoundedCornerResDelegate.dump(pw, args);
+        } else {
+            pw.println("  RoundedCornerResDelegate state:" +
+                       " skipped due to ScreenDecorations disabled");
+        }
     }
 
     @VisibleForTesting

--- a/packages/SystemUI/src/com/android/systemui/qs/QSPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSPanel.java
@@ -323,6 +323,9 @@ public class QSPanel extends LinearLayout implements Tunable {
     }
 
     private void updateViewPositions() {
+        if (mChildrenLayoutTop == null || mChildrenLayoutTop.isEmpty()) {
+            return;
+        }
         // Adjust view positions based on tile squishing
         int tileHeightOffset = mTileLayout.getTilesHeight() - mTileLayout.getHeight();
 

--- a/services/core/java/com/android/server/wm/ActivityClientController.java
+++ b/services/core/java/com/android/server/wm/ActivityClientController.java
@@ -352,8 +352,9 @@ class ActivityClientController extends IActivityClientController.Stub {
             synchronized (mGlobalLock) {
                 final int taskId = ActivityRecord.getTaskForActivityLocked(token, !nonRoot);
                 final Task task = mService.mRootWindowContainer.anyTaskForId(taskId);
-                if (task != null) {
-                    return ActivityRecord.getRootTask(token).moveTaskToBack(task);
+                final Task rootTask = ActivityRecord.getRootTask(token);
+                if (task != null && rootTask != null) {
+                    return rootTask.moveTaskToBack(task);
                 }
             }
         } finally {

--- a/services/core/java/com/android/server/wm/ActivityRecord.java
+++ b/services/core/java/com/android/server/wm/ActivityRecord.java
@@ -3849,6 +3849,10 @@ final class ActivityRecord extends WindowToken implements WindowManagerService.A
             return false;
         }
 
+        if (task == null){
+            return false;
+        }
+
         EventLogTags.writeWmDestroyActivity(mUserId, System.identityHashCode(this),
                 task.mTaskId, shortComponentName, reason);
 


### PR DESCRIPTION
This series of null pointer dereferences may cause the render thread to abort. Among them, 1b01c3bc7cdd37d69918ce7292d235e9edd5af47 appears the most. Please review. Thanks