### PR TITLE
Add feature/option to force LTE_CA (4G+)

### DIFF
--- a/telephony/java/android/telephony/NetworkRegistrationInfo.java
+++ b/telephony/java/android/telephony/NetworkRegistrationInfo.java
@@ -26,6 +26,7 @@ import android.compat.annotation.EnabledSince;
 import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.os.SystemProperties;
 import android.telephony.AccessNetworkConstants.TransportType;
 import android.telephony.Annotation.NetworkType;
 import android.text.TextUtils;
@@ -631,6 +632,11 @@ public final class NetworkRegistrationInfo implements Parcelable {
      * @hide
      */
     public void setAccessNetworkTechnology(@NetworkType int tech) {
+        // HACK: Force LTE Carrier Aggregation
+        if (SystemProperties.getBoolean("persist.sys.radio.force_lte_ca", false)
+                && tech == TelephonyManager.NETWORK_TYPE_LTE) {
+            mIsUsingCarrierAggregation = true;
+        }
         if (tech == TelephonyManager.NETWORK_TYPE_LTE_CA) {
             // For old device backward compatibility support
             tech = TelephonyManager.NETWORK_TYPE_LTE;


### PR DESCRIPTION
HACK: telephony Conditionally force enable LTE_CA

For devices that do not support 4G+ by default, this option forces 4G+ (Carrier Aggregation) to be activated.