### PR TITLE
core: Broadcast intent when display power state changes

### DIFF
--- a/core/java/android/content/Intent.java
+++ b/core/java/android/content/Intent.java
@@ -4279,6 +4279,13 @@ public class Intent implements Parcelable, Cloneable {
     public static final String ACTION_OVERLAY_CHANGED = "android.intent.action.OVERLAY_CHANGED";
 
     /**
+     * Broadcast Action: Display power state has changed.
+     * @hide
+     */
+    public static final String ACTION_DISPLAY_STATE_CHANGED =
+            "android.intent.action.DISPLAY_STATE_CHANGED";
+
+    /**
      * Activity Action: Allow the user to select and return one or more existing
      * documents. When invoked, the system will display the various
      * {@link DocumentsProvider} instances installed on the device, letting the

--- a/core/res/AndroidManifest.xml
+++ b/core/res/AndroidManifest.xml
@@ -815,6 +815,7 @@
     <protected-broadcast android:name="android.service.autofill.action.DELAYED_FILL" />
     <protected-broadcast android:name="android.app.action.PROVISIONING_COMPLETED" />
     <protected-broadcast android:name="android.app.action.LOST_MODE_LOCATION_UPDATE" />
+    <protected-broadcast android:name="android.intent.action.DISPLAY_STATE_CHANGED" />
 
     <!-- Added in U -->
     <protected-broadcast android:name="android.intent.action.PROFILE_ADDED" />

--- a/services/core/java/com/android/server/display/DisplayManagerService.java
+++ b/services/core/java/com/android/server/display/DisplayManagerService.java
@@ -379,6 +379,13 @@ public final class DisplayManagerService extends SystemService {
             if (state != Display.STATE_OFF) {
                 requestDisplayStateInternal(displayId, state, brightness, sdrBrightness);
             }
+
+            if (stateChanged) {
+                Intent intent = new Intent(Intent.ACTION_DISPLAY_STATE_CHANGED)
+                        .addFlags(Intent.FLAG_RECEIVER_REGISTERED_ONLY
+                                | Intent.FLAG_RECEIVER_FOREGROUND);
+                mContext.sendBroadcastAsUser(intent, UserHandle.ALL);
+            }
         }
     };
 


### PR DESCRIPTION
Other (system) apps can use this to perform specific tasks, such as for DOZE state.

Change-Id: I2c62767a60db58e3999de65fbf506e5cc137e28e

Required by XiaomiParts on my device :P 