### PR TITLE
Add option to toggle Google Play Integrity spoofing [1/2]

### DIFF
--- a/core/java/com/android/internal/util/derp/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/derp/PixelPropsUtils.java
@@ -41,6 +41,8 @@ public class PixelPropsUtils {
     private static final String TAG = PixelPropsUtils.class.getSimpleName();
     private static final boolean DEBUG = false;
 
+    private static final String SPOOF_PIXEL_INTEGRITY = "persist.sys.pixelprops.integrity";
+
     private static final Map<String, Object> propsToChangePixel8Pro;
     private static final Map<String, Object> propsToChangePixelXL;
 
@@ -222,6 +224,8 @@ public class PixelPropsUtils {
     }
 
     private static void spoofBuildGms() {
+        if (!SystemProperties.getBoolean(SPOOF_PIXEL_INTEGRITY, true))
+            return;
         // Alter build parameters to avoid hardware attestation enforcement
         setPropValue("BRAND", "google");
         setPropValue("MANUFACTURER", "Google");
@@ -238,6 +242,8 @@ public class PixelPropsUtils {
     }
 
     public static void onEngineGetCertificateChain() {
+        if (!SystemProperties.getBoolean(SPOOF_PIXEL_INTEGRITY, true))
+            return;
         // Check stack for SafetyNet or Play Integrity
         if (isCallerSafetyNet()) {
             Log.i(TAG, "Blocked key attestation");


### PR DESCRIPTION
I already confirmed that this commit allows ROMs to use third-party modules bypass DEVICE_INTEGRITY instead of staying at BASIC_INTEGRITY when the fingerprint key expires.

Currently, we have **hardcoded** the fingerprint key used for device integrity checks by GMS into framework_base. This approach means that updating our fingerprint key **requires repeatedly updating framework_base**. In other words, outdated ROMs will only be able to achieve **BASIC_INTEGRITY**, even if the ROM's fingerprint key is capable of achieving DEVICE_INTEGRITY. Some ROMs solutions address this issue by converting the hardcoded content in spoofBuildGms into an overlay, but it's clear that we haven't adopted that commit at this stage.

If you have any objections to this commit or what I’ve mentioned above, you’re right—I don't want to create unnecessary conflicts over this matter.